### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Alerta monitoring tool was developed with the following aims in mind:
 
 ### Requirements
 
-Release 9 only supports Python 3.9 or higher.
+Release 9 only supports Python 3.9-3.12.
 
 The only mandatory dependency is MongoDB or PostgreSQL. Everything else is optional.
 
@@ -55,7 +55,7 @@ Below are the steps to set up and run the Alerta backend on a local machine for 
 
 #### Prerequisites:
 
-- Python 3.9 or higher
+- Python 3.9-3.12
 - Docker for running PostgreSQL
 - Git for cloning the repository (if applicable)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export FLASK_DEBUG=1
 flask run --port 8080
 ```
 
-> **Note**: After starting, the API will be available at http://localhost:8080/api
+> **Note**: After starting, the API will be available at http://localhost:8080/
 
 #### 5. Create admin account
 


### PR DESCRIPTION
When I tried running this project with Python 13 I faced the issue with the missing dependency `imghdr` which has been removed in Python 13: https://docs.python.org/3/library/imghdr.html. I was able to run the project with Python 3.12.9, so I updated the README to reflect this fact.

I also change the API URL from `/api` to `/`. The endpoints are e.g. `/alerts`, without the `/api` prefix.